### PR TITLE
Save mask outputs alongside depth maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,12 @@ background is completely black. Images can be of any resolution; the script
 resizes each one so the width is 512&nbsp;pixels before inference and runs only
 on GPU&nbsp;0.
 
-Only the print prediction, the colorized depth (`depth_pred`), and the inverted
-grayscale depth (`depth_gray`) are saved for each input. Grid layouts, masks,
-and the original image are omitted. Depth values are normalized using the 0th
-and 99th percentiles by default to boost contrast. All outputs are resized to a
-width of 512&nbsp;pixels (while keeping the original aspect ratio) and saved under
-`results/shoerinsics/masked_images/` in the repository root.
+Only the print prediction, the colorized depth (`depth_pred`), the inverted
+grayscale depth (`depth_gray`), and the mask (`mask`) are saved for each input.
+Grid layouts and the original image are omitted. Depth values are normalized
+using the 0th and 99th percentiles by default to boost contrast. All outputs are
+resized to a width of 512&nbsp;pixels (while keeping the original aspect ratio) and
+saved under `results/shoerinsics/masked_images/` in the repository root.
 
 To instead generate a grayscale depth map where closer areas are darker and
 farther areas are brighter, run `grayscale2.py` with the same arguments as

--- a/code/grayscale.py
+++ b/code/grayscale.py
@@ -126,6 +126,7 @@ def main():
         visuals['print pred'] = print_pred
         visuals['depth pred'] = depth_color
         visuals['depth gray'] = depth_gray
+        visuals['mask'] = mask_norm.float()
 
         save_individual_images(
             visuals,

--- a/code/grayscale2.py
+++ b/code/grayscale2.py
@@ -126,6 +126,7 @@ def main():
         visuals['print pred'] = print_pred
         visuals['depth pred'] = depth_color
         visuals['depth gray'] = depth_gray
+        visuals['mask'] = mask_norm.float()
 
         save_individual_images(
             visuals,


### PR DESCRIPTION
## Summary
- Save binary mask images alongside depth and print predictions during grayscale inference
- Document mask output in README

## Testing
- `python -m py_compile code/grayscale.py code/grayscale2.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2dd7e1ff483228f0484936916b91c